### PR TITLE
Fix for missing sync button

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -6,13 +6,10 @@ let button, helpLink;
 //waits for DOM to load and then injects `Sync with Anki` button into web page.
 function injectSyncButton() {
   if (document.body && document.head
-    && document.getElementsByClassName('learned-items__toolbar-item')[1]
-    && document.getElementsByClassName('learned-items__toolbar-item')[1].children.length >= 1
+    && document.getElementsByClassName('learned-items__toolbar')[0]
+	&& document.getElementsByClassName('learned-items__toolbar')[0].children.length > 1
   ) {
-    const sibling = document.getElementsByClassName('learned-items__toolbar-item')[1];
-    sibling.style.display = "flex"
-    document.getElementsByClassName("learned-items__toolbar")[0].style.display = "flex"
-    document.getElementsByClassName("learned-items__toolbar")[0].style.alignItems = "end"
+    const parent = document.getElementsByClassName('learned-items__toolbar')[0];
 
     const div = document.createElement("div");
     div.id = "wrapperDiv"
@@ -35,7 +32,7 @@ function injectSyncButton() {
 
     div.append(button)
     div.append(helpLink)
-    sibling.appendChild(div)
+    parent.appendChild(div)
 
   } else {
     requestIdleCallback(injectSyncButton);

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -7,7 +7,7 @@ let button, helpLink;
 function injectSyncButton() {
   if (document.body && document.head
     && document.getElementsByClassName('learned-items__toolbar')[0]
-	&& document.getElementsByClassName('learned-items__toolbar')[0].children.length > 1
+	  && document.getElementsByClassName('learned-items__toolbar')[0].children.length > 1
   ) {
     const parent = document.getElementsByClassName('learned-items__toolbar')[0];
 


### PR DESCRIPTION
Fixes issue #17

It seems that Babbel slightly changed the layout of the review manager page, including the html class names currently used to verify that the required html elements are loaded in the DOM before injecting the sync button.

This pull request handles the new html class names and toolbar layout.
With these changes, the button is displayed again.

![image](https://user-images.githubusercontent.com/64231217/179370115-51f60a8e-8706-4557-a161-95f1a59d5ba5.png)
