### PR TITLE
Fixed missing sync button by using new attribute selector

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -4,7 +4,7 @@ let button, helpLink;
 
 //waits for DOM to load the review button and then injects `Sync with Anki` button into web page.
 function injectSyncButton() {
-  const reviewButtonNodeList = document.querySelectorAll("a[href*='review?'][color='secondary']")
+  const reviewButtonNodeList = document.querySelectorAll("a[href*='review?'][color='secondary-default']")
   if (reviewButtonNodeList && reviewButtonNodeList.length === 1) {
     const parent = reviewButtonNodeList[0].parentElement;
     const sibling = reviewButtonNodeList[0];
@@ -118,7 +118,7 @@ function createSyncButtonDiv() {
   div.style.marginLeft = ".938rem"
 
   button = document.createElement("a");
-  button.className = 'btn btn--primary'
+  button.className = 'babbel-button babbel-font'
 
   button.innerHTML =
     '<img id="sync_spinner" src="https://icongr.am/clarity/sync.svg?size=20&color=FFFFFF" style="margin-right: 8px" alt="spin me baby"/>' +
@@ -126,9 +126,9 @@ function createSyncButtonDiv() {
   button.addEventListener('click', syncHandler);
 
   helpLink = document.createElement("a");
-  helpLink.className = 'helpLink'
+  helpLink.className = 'helpLink babbel-font'
   helpLink.href = "https://github.com/pavelgordon/babbel2anki-chrome-extension#more-detailed-guide"
-  helpLink.innerText = "Troubleshoot"
+  helpLink.innerText = "Troubleshoot Babbel2Anki"
 
   div.append(button)
   div.append(helpLink)

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -24,11 +24,38 @@ h1 {
 }
 .helpLink {
   text-decoration: underline;
-  display: initial;
+  display: inline-flex;
+  justify-content: center;
   border: none !important;
+  margin-top: 8px;
 }
 
+.babbel-button {
+  height: 44px;
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 4000px;
+  cursor: pointer;
+  display: inline-flex;
+  padding: 12px 24px;
+  width: auto;
+  flex-shrink: 0;
+  -webkit-box-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  align-items: center;
+  outline: none;
+  text-decoration: none;
+  margin: 0px;
+  transition: all 100ms ease-out 0s;
+  background-color: rgb(254, 77, 1);
+  color: white;
+  border: 1px solid rgb(21, 21, 21);
+}
 
-
-
-
+.babbel-font {
+  font-family: "Graphik LC", sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.25rem;
+}


### PR DESCRIPTION
Fixes issue #17  (for the third time)

Babbel changed the page layout again and the sync button was missing again.
The fix was to slightly alter the attribute selector.
Considering that this is the third time for a fix for the missing sync button, this can be viewed as a temporary fix until a better solution is in place.

![image](https://github.com/pavelgordon/babbel2anki-chrome-extension/assets/64231217/40ee17a4-dce5-4c26-a46c-682d7e466b60)
